### PR TITLE
update service endpoint section

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -137,9 +137,36 @@ Object Signing / Encryption |
 
 ## Service Endpoints
 
-::: warning
-This will be updated
-:::
+The following DID Document Service Endpoint entries ****MUST**** be present in the DID Document of a target DID for resolution to properly locate the URI for addressing a DID owner's Decentralized Web Nodes:
+
+```json
+{
+  "id": "did:example:alice",
+  "service": [{
+    "id": "#dwn",
+    "type": "DecentralizedWebNode",
+    "enc": [
+      "#dwn-enc"
+    ],
+    "sig": [
+      "#dwn-sig"
+    ],
+    "serviceEndpoint": [
+      "did:example:host",
+      "https://dwn.example.com"
+    ]
+  }]
+}
+```
+
+- Service Endpoints ****MUST**** contain an `id` property and it ****MUST**** be set to `#dwn`.
+- Service Endpoints ****MUST**** contain a `type` property and it ****MUST**** be set to `DecentralizedWebNode`.
+- Service Endpoints ****MUST**** contain a `serviceEndpoint` property and it ****MAY**** be set to:
+  - either a `string` value which represents the `URL` associated with the `DWN`
+  - an array of `string` values which each value represents a `URL` associated with a `DWN`
+- Service Endpoints ****MUST**** contain an `enc` property and it ****MUST**** be a `string` value or an array of `string` values which represent the `keyId` associated with `encrypting` data.
+- Service Endpoints ****MUST**** contain a `sig`property and it ****MUST**** be a `string` value or an array of `string` values which represent the `keyId` associated with `signing` data.
+
 
 ## Messages
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -161,12 +161,12 @@ The following DID Document Service Endpoint entries ****MUST**** be present in t
 
 - Service Endpoints ****MUST**** contain an `id` property and it ****MUST**** be set to `#dwn`.
 - Service Endpoints ****MUST**** contain a `type` property and it ****MUST**** be set to `DecentralizedWebNode`.
-- Service Endpoints ****MUST**** contain a `serviceEndpoint` property and it ****MAY**** be set to:
-  - either a `string` value which represents the `URL` associated with the `DWN`
-  - an array of `string` values which each value represents a `URL` associated with a `DWN`
+- Service Endpoints ****MUST**** contain a `serviceEndpoint` property and it ****MUST**** be set to one of the following:
+  - a `string` value which represents the `URL` associated with the `DWN`
+  - an array of `string` values, each of which represents the `URL` associated with a `DWN`
 - If a Service Endpoint `URL` is a `DID`, it ****MUST NOT**** not be followed more than 1 level deep when resolving.
-- Service Endpoints ****MUST**** contain an `enc` property and it ****MUST**** be a `string` value or an array of `string` values which represent the `keyId` associated with `encrypting` data.
-- Service Endpoints ****MUST**** contain a `sig`property and it ****MUST**** be a `string` value or an array of `string` values which represent the `keyId` associated with `signing` data.
+- Service Endpoints ****MUST**** contain an `enc` property which ****MUST**** be a `string` value or an array of `string` values, each of which represents a `keyId` associated with `encrypting` data.
+- Service Endpoints ****MUST**** contain a `sig` property which ****MUST**** be a `string` value or an array of `string` values, each of which represents a `keyId` associated with `signing` data.
 
 
 ## Messages

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -164,6 +164,7 @@ The following DID Document Service Endpoint entries ****MUST**** be present in t
 - Service Endpoints ****MUST**** contain a `serviceEndpoint` property and it ****MAY**** be set to:
   - either a `string` value which represents the `URL` associated with the `DWN`
   - an array of `string` values which each value represents a `URL` associated with a `DWN`
+- If a Service Endpoint `URL` is a `DID`, it ****MUST NOT**** not be followed more than 1 level deep when resolving.
 - Service Endpoints ****MUST**** contain an `enc` property and it ****MUST**** be a `string` value or an array of `string` values which represent the `keyId` associated with `encrypting` data.
 - Service Endpoints ****MUST**** contain a `sig`property and it ****MUST**** be a `string` value or an array of `string` values which represent the `keyId` associated with `signing` data.
 


### PR DESCRIPTION
First pass at aligning the `Service Endpoints` sections.

When looking at this I found myself asking a question which I figured will be good to document here and talk on the call.

Does the `enc` or `sig` key have to reference a key that is associated with the resolved `DID`?

For example could the JSON example shown have `"sig": ["did:eample:bob#dwn-sig"]` ?